### PR TITLE
Enable translation of mouse buttons

### DIFF
--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -233,22 +233,28 @@ bool CInputManager::ButtonState(libretro_device_t device, unsigned int port, uns
 
 int CInputManager::DeltaX(libretro_device_t device, unsigned int port)
 {
-  (void) device;
-  (void) port;
-  CLockObject lock(m_mouseMutex);
-  int x = m_mouseRelativePosition.x;
-  m_mouseRelativePosition.x = 0;
-  return x;
+  int deltaX = 0;
+
+  if (device == RETRO_DEVICE_MOUSE || device == RETRO_DEVICE_LIGHTGUN)
+  {
+    if (m_devices[GAME_INPUT_PORT_MOUSE])
+      deltaX = m_devices[GAME_INPUT_PORT_MOUSE]->Input().RelativePointerDeltaX();
+  }
+
+  return deltaX;
 }
 
 int CInputManager::DeltaY(libretro_device_t device, unsigned int port)
 {
-  (void) device;
-  (void) port;
-  CLockObject lock(m_mouseMutex);
-  int y = m_mouseRelativePosition.y;
-  m_mouseRelativePosition.y = 0;
-  return y;
+  int deltaY = 0;
+
+  if (device == RETRO_DEVICE_MOUSE || device == RETRO_DEVICE_LIGHTGUN)
+  {
+    if (m_devices[GAME_INPUT_PORT_MOUSE])
+      deltaY = m_devices[GAME_INPUT_PORT_MOUSE]->Input().RelativePointerDeltaX();
+  }
+
+  return deltaY;
 }
 
 bool CInputManager::AnalogStickState(unsigned int port, unsigned int analogStickIndex, float& x, float& y)

--- a/src/libretro/LibretroTranslator.cpp
+++ b/src/libretro/LibretroTranslator.cpp
@@ -122,8 +122,14 @@ int LibretroTranslator::GetFeatureIndex(const std::string& strFeatureName)
   if (strFeatureName == "r3")           return RETRO_DEVICE_ID_JOYPAD_R3;
   if (strFeatureName == "leftstick")    return RETRO_DEVICE_INDEX_ANALOG_LEFT;
   if (strFeatureName == "rightstick")   return RETRO_DEVICE_INDEX_ANALOG_RIGHT;
+  if (strFeatureName == "relpointer")   return 0; // Only 1 relative pointer
   if (strFeatureName == "leftmouse")    return RETRO_DEVICE_ID_MOUSE_LEFT;
   if (strFeatureName == "rightmouse")   return RETRO_DEVICE_ID_MOUSE_RIGHT;
+  if (strFeatureName == "wheelup")      return RETRO_DEVICE_ID_MOUSE_WHEELUP;
+  if (strFeatureName == "wheeldown")    return RETRO_DEVICE_ID_MOUSE_WHEELDOWN;
+  if (strFeatureName == "middle")       return RETRO_DEVICE_ID_MOUSE_MIDDLE;
+  if (strFeatureName == "horizwheelup") return RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELUP;
+  if (strFeatureName == "horizwheeldown") return RETRO_DEVICE_ID_MOUSE_HORIZ_WHEELDOWN;
   if (strFeatureName == "trigger")      return RETRO_DEVICE_ID_LIGHTGUN_TRIGGER;
   if (strFeatureName == "cursor")       return RETRO_DEVICE_ID_LIGHTGUN_CURSOR;
   if (strFeatureName == "turbo")        return RETRO_DEVICE_ID_LIGHTGUN_TURBO;


### PR DESCRIPTION
This should enable mouse support by hardcoding the port and adding the new libretro buttons

Requires https://github.com/fetzerch/xbmc/pull/8

Sample button map: https://github.com/kodi-game/game.libretro.scummvm/pull/4
