### PR TITLE
Add support for RETRO_ENVIRONMENT_SET_CONTROLLER_INFO

### DIFF
--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -148,9 +148,8 @@ bool CInputManager::InputEvent(const game_input_event& event)
 
 void CInputManager::LogInputDescriptors(const retro_input_descriptor* descriptors)
 {
+  dsyslog("Libretro input bindings:");
   dsyslog("------------------------------------------------------------");
-  dsyslog("Libretro input bindings");
-  dsyslog("");
 
   for (const retro_input_descriptor* descriptor = descriptors;
       descriptor != nullptr && descriptor->description != nullptr && !std::string(descriptor->description).empty();
@@ -276,6 +275,26 @@ bool CInputManager::AccelerometerState(unsigned int port, float& x, float& y, fl
   }
 
   return bSuccess;
+}
+
+void CInputManager::SetControllerInfo(const retro_controller_info* info)
+{
+  dsyslog("Libretro controller info:");
+  dsyslog("------------------------------------------------------------");
+
+  for (unsigned int i = 0; i < info->num_types; i++)
+  {
+    const retro_controller_description& type = info->types[i];
+
+    libretro_device_t baseType = type.id & RETRO_DEVICE_MASK;
+    unsigned int subclass = type.id >> RETRO_DEVICE_TYPE_SHIFT;
+    std::string description = type.desc ? type.desc : "";
+
+    dsyslog("Device: %s, Subclass: %u, Description: %s",
+        LibretroTranslator::GetDeviceName(baseType), subclass, description.c_str());
+  }
+
+  dsyslog("------------------------------------------------------------");
 }
 
 void CInputManager::HandlePress(const game_key_event& key)

--- a/src/input/InputManager.cpp
+++ b/src/input/InputManager.cpp
@@ -153,7 +153,7 @@ void CInputManager::LogInputDescriptors(const retro_input_descriptor* descriptor
   dsyslog("");
 
   for (const retro_input_descriptor* descriptor = descriptors;
-      descriptor != nullptr && descriptor->description != nullptr;
+      descriptor != nullptr && descriptor->description != nullptr && !std::string(descriptor->description).empty();
       descriptor++)
   {
     std::string component = LibretroTranslator::GetComponentName(descriptor->device, descriptor->index, descriptor->id);

--- a/src/input/InputManager.h
+++ b/src/input/InputManager.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 
+struct retro_controller_info;
 struct retro_input_descriptor;
 
 namespace LIBRETRO
@@ -94,6 +95,11 @@ namespace LIBRETRO
     bool AnalogStickState(unsigned int port, unsigned int analogStickIndex, float& x, float& y);
     bool AbsolutePointerState(unsigned int port, unsigned int pointerIndex, float& x, float& y);
     bool AccelerometerState(unsigned int port, float& x, float& y, float& z);
+
+    /*!
+     * \brief Inform the frontend of controller info
+     */
+    void SetControllerInfo(const retro_controller_info* info);
 
   private:
     void HandlePress(const game_key_event& key);

--- a/src/libretro/LibretroEnvironment.cpp
+++ b/src/libretro/LibretroEnvironment.cpp
@@ -423,6 +423,15 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
 
       break;
     }
+  case RETRO_ENVIRONMENT_SET_CONTROLLER_INFO:
+    {
+      const retro_controller_info* typedData = reinterpret_cast<const retro_controller_info*>(data);
+      if (typedData)
+      {
+        CInputManager::Get().SetControllerInfo(typedData);
+      }
+      break;
+    }
   case RETRO_ENVIRONMENT_GET_RESOURCE_DIRECTORY:
     {
       retro_resource* typedData = reinterpret_cast<retro_resource*>(data);

--- a/src/libretro/LibretroEnvironment.cpp
+++ b/src/libretro/LibretroEnvironment.cpp
@@ -423,6 +423,26 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
 
       break;
     }
+  case RETRO_ENVIRONMENT_SET_PROC_ADDRESS_CALLBACK:
+  {
+    const retro_get_proc_address_interface* typedData = reinterpret_cast<const retro_get_proc_address_interface*>(data);
+    if (typedData)
+    {
+      // get_proc_address() interface not implemented
+      return false;
+    }
+    break;
+  }
+  case RETRO_ENVIRONMENT_SET_SUBSYSTEM_INFO:
+  {
+    const retro_subsystem_info* typedData = reinterpret_cast<const retro_subsystem_info*>(data);
+    if (typedData)
+    {
+      // Not implemented
+      return false;
+    }
+    break;
+  }
   case RETRO_ENVIRONMENT_SET_CONTROLLER_INFO:
     {
       const retro_controller_info* typedData = reinterpret_cast<const retro_controller_info*>(data);
@@ -432,6 +452,36 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
       }
       break;
     }
+  case RETRO_ENVIRONMENT_SET_GEOMETRY:
+  {
+    const retro_game_geometry* typedData = reinterpret_cast<const retro_game_geometry*>(data);
+    if (typedData)
+    {
+      // Not implemented
+      return false;
+    }
+    break;
+  }
+  case RETRO_ENVIRONMENT_GET_USERNAME:
+  {
+    const char** typedData = reinterpret_cast<const char**>(data);
+    if (typedData)
+    {
+      // Not implemented
+      return false;
+    }
+    break;
+  }
+  case RETRO_ENVIRONMENT_GET_LANGUAGE:
+  {
+    unsigned int* typedData = reinterpret_cast<unsigned int*>(data);
+    if (typedData)
+    {
+      // Not implemented
+      return false;
+    }
+    break;
+  }
   case RETRO_ENVIRONMENT_GET_RESOURCE_DIRECTORY:
     {
       retro_resource* typedData = reinterpret_cast<retro_resource*>(data);


### PR DESCRIPTION
It seems libretro cores either support SET_CONTROLLER_INFO or SET_INPUT_DESCRIPTORS, with Genesis Plus GX providing both.